### PR TITLE
Corrected Double-Greatsword

### DIFF
--- a/src/main/resources/data/soulsweapons/weapon_attributes/translucent_double_greatsword.json
+++ b/src/main/resources/data/soulsweapons/weapon_attributes/translucent_double_greatsword.json
@@ -1,3 +1,3 @@
 {
-    "parent": "bettercombat:mace"
+    "parent": "bettercombat:twin_blade"
 }


### PR DESCRIPTION
Weapon is long and has 2 ends of a blade, it technically falls under a twinblade 

- changed "bettercombat:mace" to "bettercombat:twin_blade", this should automatically make the weapon handle like a twinblade and also in the process make a double handed requirement
- fixes #35 