### PR TITLE
1.20 1.20.1 Crash fixes and Calculated Fall tweaks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.21
 	
 # Mod Properties
-	mod_version = 1.1.3-1.20-fabric
+	mod_version = 1.1.4-1.20-fabric
 	maven_group = net.soulsweaponry
 	archives_base_name = soulslike-weaponry
 	modid=soulsweapons

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.21
 	
 # Mod Properties
-	mod_version = 1.1.4-1.20-fabric
+	mod_version = 1.1.5-1.20-fabric
 	maven_group = net.soulsweaponry
 	archives_base_name = soulslike-weaponry
 	modid=soulsweapons

--- a/src/main/java/net/soulsweaponry/config/ConfigConstructor.java
+++ b/src/main/java/net/soulsweaponry/config/ConfigConstructor.java
@@ -9,7 +9,7 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static boolean disable_enchantment_fast_hands = false;
     @Entry public static boolean disable_enchantment_posture_breaker = false;
     @Entry public static boolean disable_enchantment_stagger = false;
-    
+
     @Entry public static boolean disable_recipe_bloodthirster = false;
     @Entry public static boolean disable_recipe_comet_spear = false;
     @Entry public static boolean disable_recipe_darkin_blade = false;
@@ -49,6 +49,55 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static boolean disable_recipe_darkmoon_longbow = false;
     @Entry public static boolean disable_recipe_enhanced_arkenplate = false;
     @Entry public static boolean disable_recipe_enhanced_withered_chest = false;
+
+    @Entry public static boolean inform_player_about_disabled_use = true;
+    @Entry public static boolean disable_use_bluemoon_shortsword = false;
+    @Entry public static boolean disable_use_bluemoon_greatsword = false;
+    @Entry public static boolean disable_use_moonlight_shortsword = false;
+    @Entry public static boolean disable_use_moonlight_greatsword = false;
+    @Entry public static boolean disable_use_pure_moonlight_greatsword = false;
+    @Entry public static boolean disable_use_bloodthirster = false;
+    @Entry public static boolean disable_use_darkin_blade = false;
+    @Entry public static boolean disable_use_dragon_staff = false;
+    @Entry public static boolean disable_use_withered_wabbajack = false;
+    @Entry public static boolean disable_use_whirligig_sawblade = false;
+    @Entry public static boolean disable_use_dragonslayer_swordspear = false;
+    @Entry public static boolean disable_use_rageblade = false;
+    @Entry public static boolean disable_use_heap_of_raw_iron = false;
+    @Entry public static boolean disable_use_nightfall = false;
+    @Entry public static boolean disable_use_comet_spear = false;
+    @Entry public static boolean disable_use_lich_bane = false;
+    @Entry public static boolean disable_use_galeforce = false;
+    @Entry public static boolean disable_use_draugr = false;
+    @Entry public static boolean disable_use_dawnbreaker = false;
+    @Entry public static boolean disable_use_soul_reaper = false;
+    @Entry public static boolean disable_use_forlorn_scythe = false;
+    @Entry public static boolean disable_use_leviathan_axe = false;
+    @Entry public static boolean disable_use_skofnung = false;
+    @Entry public static boolean disable_use_skofnung_stone = false;
+    @Entry public static boolean disable_use_mjolnir = false;
+    @Entry public static boolean disable_use_sword_of_freyr = false;
+    // @Entry public static boolean disable_use_sting = false;
+    @Entry public static boolean disable_use_featherlight = false;
+    @Entry public static boolean disable_use_crucible_sword = false;
+    @Entry public static boolean disable_use_darkin_scythe = false;
+    @Entry public static boolean disable_use_shadow_assassin_scythe = false;
+    @Entry public static boolean disable_use_draupnir_spear = false;
+    @Entry public static boolean disable_use_holy_moonlight_greatsword = false;
+    @Entry public static boolean disable_use_holy_moonlight_sword = false;
+    @Entry public static boolean disable_use_frostmourne = false;
+    @Entry public static boolean disable_use_master_sword = false;
+    @Entry public static boolean disable_use_nights_edge = false;
+    @Entry public static boolean disable_use_empowered_dawnbreaker = false;
+    @Entry public static boolean disable_use_kraken_slayer_bow = false;
+    @Entry public static boolean disable_use_kraken_slayer_crossbow = false;
+    @Entry public static boolean disable_use_darkmoon_longbow = false;
+    @Entry public static boolean disable_use_hunter_pistol = false;
+    @Entry public static boolean disable_use_hunter_blunderbuss = false;
+    @Entry public static boolean disable_use_gatling_gun = false;
+    @Entry public static boolean disable_use_hunter_cannon = false;
+
+    @Entry public static boolean disable_use_chaos_orb = false;
 
     @Entry(min=0,max=100) public static int withered_demon_spawnrate = 20;
     @Entry(min=0,max=100) public static int moderatly_sized_chungus_spawnrate = 100;

--- a/src/main/java/net/soulsweaponry/config/ConfigConstructor.java
+++ b/src/main/java/net/soulsweaponry/config/ConfigConstructor.java
@@ -97,12 +97,14 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static int comet_spear_ability_damage = 10;
     @Entry public static int comet_spear_skyfall_ability_cooldown = 400;
     @Entry public static int comet_spear_throw_ability_cooldown = 25;
+    @Entry public static float comet_spear_launch_multiplier = 0.35f;
     @Entry public static int crucible_sword_normal_damage = 9;
     @Entry public static int crucible_sword_empowered_damage = 30;
     @Entry public static int crucible_sword_empowered_cooldown = 300;
     @Entry public static int darkin_blade_damage = 11;
     @Entry public static int darkin_blade_ability_damage = 12;
     @Entry public static int darkin_blade_ability_cooldown = 150;
+    @Entry public static float darkin_blade_launch_multiplier = 0.25f;
     @Entry public static int darkin_scythe_damage = 9;
     @Entry public static int darkin_scythe_bonus_damage = 3;
     @Entry public static int darkin_scythe_max_souls = 100;
@@ -129,6 +131,7 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static int dragonslayer_swordspear_lightning_amount = 1;
     @Entry public static int dragonslayer_swordspear_throw_cooldown = 100;
     @Entry public static int dragonslayer_swordspear_ability_cooldown = 300;
+    @Entry public static float dragonslayer_swordspear_launch_multiplier = 0.25f;
     @Entry public static int dragon_staff_damage = 8;
     @Entry public static int dragon_staff_aura_strength = 1;
     @Entry public static int dragon_staff_cooldown = 100;
@@ -144,6 +147,7 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static int forlorn_scythe_damage = 11;
     @Entry public static int featherlight_damage = 8;
     @Entry public static float featherlight_attack_speed = 1.6f;
+    @Entry public static float featherlight_launch_multiplier = 0.20f;
     @Entry public static int frostmourne_damage = 11;
     @Entry public static int frostmourne_summoned_allies_cap = 50;
     @Entry public static float galeforce_bonus_damage = 1.0f;
@@ -196,6 +200,7 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static int nightfall_smash_cooldown = 300;
     @Entry public static int nightfall_summoned_allies_cap = 50;
     @Entry(min=0, max=1) public static double nightfall_summon_chance = 0.3D;
+    @Entry public static float nightfall_launch_multiplier = 0.30f;
     @Entry public static int nights_edge_weapon_damage = 10;
     @Entry public static int nights_edge_ability_cooldown = 120;
     @Entry public static float nights_edge_ability_damage = 10f;
@@ -220,6 +225,8 @@ public class ConfigConstructor extends MidnightConfig {
     @Entry public static int whirligig_sawblade_cooldown = 100;
     @Entry public static int whirligig_sawblade_use_time = 100;
     @Entry public static int withered_wabbajack_damage = 8;
+
+    @Entry public static boolean calculated_fall_hits_immune_entities = false;
 
     @Entry public static int max_posture_loss = 200;
     @Entry public static boolean enable_shield_parry = true;

--- a/src/main/java/net/soulsweaponry/entity/ai/goal/MoonknightGoal.java
+++ b/src/main/java/net/soulsweaponry/entity/ai/goal/MoonknightGoal.java
@@ -642,6 +642,10 @@ public class MoonknightGoal extends Goal {
     }
 
     public boolean canSummon() {
+        //fix crash on mob summons
+        if(this.pos == null){
+            this.pos = new BlockPos(this.boss.getBlockX() + this.boss.getRandom().nextInt(20) - 10, this.boss.getBlockY() - 2,  this.boss.getBlockZ() + this.boss.getRandom().nextInt(20) - 10);
+        }
         if (!this.boss.getWorld().getBlockState(this.pos).isAir()) {
             this.pos = new BlockPos(this.pos.getX(), this.pos.getY() + 1, this.pos.getZ());
             this.canSummon();

--- a/src/main/java/net/soulsweaponry/entity/ai/goal/ReturningKnightGoal.java
+++ b/src/main/java/net/soulsweaponry/entity/ai/goal/ReturningKnightGoal.java
@@ -61,6 +61,10 @@ public class ReturningKnightGoal extends Goal {
     }
 
     public boolean canSummon() {
+        //fix crash on mob summons
+        if(this.pos == null){
+            this.pos = new BlockPos(this.boss.getBlockX() + this.boss.getRandom().nextInt(32) - 16, this.boss.getBlockY() - 3, this.boss.getBlockZ() + this.boss.getRandom().nextInt(32) - 16);
+        }
         if (!this.boss.getWorld().getBlockState(this.pos).isAir()) {
             this.pos = new BlockPos(this.pos.getX(), this.pos.getY() + 1, this.pos.getZ());
             this.canSummon();

--- a/src/main/java/net/soulsweaponry/items/AbstractDawnbreaker.java
+++ b/src/main/java/net/soulsweaponry/items/AbstractDawnbreaker.java
@@ -11,6 +11,7 @@ import net.minecraft.item.ToolMaterial;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundCategory;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.Box;
 import net.soulsweaponry.config.ConfigConstructor;
 import net.soulsweaponry.registry.EffectRegistry;
@@ -33,6 +34,12 @@ public abstract class AbstractDawnbreaker extends SwordItem implements GeoItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_dawnbreaker) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         target.setOnFireFor(4 + 3 * EnchantmentHelper.getLevel(Enchantments.FIRE_ASPECT, stack));
         if (target.isUndead() || ConfigConstructor.dawnbreaker_affect_all_entities) {
             if (target.isDead()) {

--- a/src/main/java/net/soulsweaponry/items/Bloodthirster.java
+++ b/src/main/java/net/soulsweaponry/items/Bloodthirster.java
@@ -38,6 +38,12 @@ public class Bloodthirster extends SwordItem implements GeoItem {
     }
 
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_bloodthirster) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         super.postHit(stack, target, attacker);
         if (attacker instanceof PlayerEntity player) {
             if (!player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
@@ -63,6 +69,9 @@ public class Bloodthirster extends SwordItem implements GeoItem {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.LIFE_STEAL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.OVERHEAL, stack, tooltip);
         } else {
+            if(ConfigConstructor.disable_use_bloodthirster){
+                tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+            }
             tooltip.add(Text.translatable("tooltip.soulsweapons.shift"));
         }
         super.appendTooltip(stack, world, tooltip, context);

--- a/src/main/java/net/soulsweaponry/items/BluemoonGreatsword.java
+++ b/src/main/java/net/soulsweaponry/items/BluemoonGreatsword.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
+import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
@@ -18,6 +19,12 @@ public class BluemoonGreatsword extends MoonlightGreatsword implements IChargeNe
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_bluemoon_greatsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         this.addCharge(stack, this.getAddedCharge(stack));
         return super.postHit(stack, target, attacker);
     }
@@ -25,6 +32,12 @@ public class BluemoonGreatsword extends MoonlightGreatsword implements IChargeNe
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_bluemoon_greatsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(itemStack);
+        }
         if (itemStack.getDamage() < itemStack.getMaxDamage() - 1 && (this.isCharged(itemStack) ||
                 user.isCreative() || user.hasStatusEffect(EffectRegistry.MOON_HERALD))) {
             user.setCurrentHand(hand);

--- a/src/main/java/net/soulsweaponry/items/BluemoonShortsword.java
+++ b/src/main/java/net/soulsweaponry/items/BluemoonShortsword.java
@@ -1,10 +1,24 @@
 package net.soulsweaponry.items;
 
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
+import net.minecraft.text.Text;
+import net.minecraft.world.World;
 import net.soulsweaponry.config.ConfigConstructor;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class BluemoonShortsword extends MoonlightShortsword {
     public BluemoonShortsword(ToolMaterial toolMaterial, float attackSpeed, Settings settings) {
         super(toolMaterial, ConfigConstructor.bluemoon_shortsword_damage, attackSpeed, settings);
+    }
+    @Override
+    public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_bluemoon_shortsword) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
+        super.appendTooltip(stack, world, tooltip, context);
     }
 }

--- a/src/main/java/net/soulsweaponry/items/Blunderbuss.java
+++ b/src/main/java/net/soulsweaponry/items/Blunderbuss.java
@@ -1,5 +1,6 @@
 package net.soulsweaponry.items;
 
+import net.minecraft.client.item.TooltipContext;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.player.PlayerEntity;
@@ -8,6 +9,7 @@ import net.minecraft.particle.ParticleTypes;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.Vec3d;
@@ -17,6 +19,9 @@ import net.soulsweaponry.entity.projectile.SilverBulletEntity;
 import net.soulsweaponry.registry.EnchantRegistry;
 import net.soulsweaponry.registry.ItemRegistry;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class Blunderbuss extends GunItem {
 
@@ -47,6 +52,12 @@ public class Blunderbuss extends GunItem {
     
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_hunter_blunderbuss) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         boolean bl = user.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
         ItemStack itemStack = user.getProjectileType(stack);
         if (!itemStack.isEmpty() || bl) {
@@ -94,5 +105,12 @@ public class Blunderbuss extends GunItem {
             return TypedActionResult.success(stack, world.isClient());
         }
         return TypedActionResult.fail(stack); 
+    }
+    @Override
+    public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_hunter_blunderbuss) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
+        super.appendTooltip(stack, world, tooltip, context);
     }
 }

--- a/src/main/java/net/soulsweaponry/items/ChaosOrb.java
+++ b/src/main/java/net/soulsweaponry/items/ChaosOrb.java
@@ -13,6 +13,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.minecraft.world.event.GameEvent;
+import net.soulsweaponry.config.ConfigConstructor;
 import net.soulsweaponry.entity.projectile.ChaosOrbEntity;
 import net.soulsweaponry.registry.EntityRegistry;
 import org.jetbrains.annotations.Nullable;
@@ -28,6 +29,12 @@ public class ChaosOrb extends Item {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_chaos_orb) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         if (!world.isClient) {
             ChaosOrbEntity orb = new ChaosOrbEntity(EntityRegistry.CHAOS_ORB_ENTITY, world);
             orb.setPosition(user.getX(), user.getEyeY(), user.getZ());
@@ -46,6 +53,9 @@ public class ChaosOrb extends Item {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_chaos_orb){
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         super.appendTooltip(stack, world, tooltip, context);
         for (int i = 1; i < 3 + 1; i++) {
             tooltip.add(Text.translatable("tooltip.soulsweapons.chaos_orb." + i).formatted(Formatting.DARK_GRAY));

--- a/src/main/java/net/soulsweaponry/items/CometSpear.java
+++ b/src/main/java/net/soulsweaponry/items/CometSpear.java
@@ -134,8 +134,8 @@ public class CometSpear extends DetonateGroundItem implements GeoItem {
     }
 
     @Override
-    public float getLaunchDivisor() {
-        return 35;
+    public float getLaunchMultiplier() {
+        return ConfigConstructor.comet_spear_launch_multiplier;
     }
 
     @Override

--- a/src/main/java/net/soulsweaponry/items/CometSpear.java
+++ b/src/main/java/net/soulsweaponry/items/CometSpear.java
@@ -47,6 +47,12 @@ public class CometSpear extends DetonateGroundItem implements GeoItem {
 
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
         if (user instanceof PlayerEntity playerEntity) {
+            if(ConfigConstructor.disable_use_comet_spear) {
+                if(ConfigConstructor.inform_player_about_disabled_use){
+                    user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+                }
+                return;
+            }
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
                 float enchant = WeaponUtil.getEnchantDamageBonus(stack);
@@ -113,6 +119,9 @@ public class CometSpear extends DetonateGroundItem implements GeoItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_comet_spear) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SKYFALL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.INFINITY, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/CrucibleSword.java
+++ b/src/main/java/net/soulsweaponry/items/CrucibleSword.java
@@ -16,8 +16,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.soulsweaponry.config.ConfigConstructor;
 import net.soulsweaponry.util.WeaponUtil;
@@ -73,7 +71,11 @@ public class CrucibleSword extends SwordItem {
         Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers;
         if (slot == EquipmentSlot.MAINHAND) {
             ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
-            builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", (this.isEmpowered(stack) ? ConfigConstructor.crucible_sword_empowered_damage : ConfigConstructor.crucible_sword_normal_damage) - 1, EntityAttributeModifier.Operation.ADDITION));
+            if(ConfigConstructor.disable_use_crucible_sword) {
+                builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", ConfigConstructor.crucible_sword_normal_damage - 1, EntityAttributeModifier.Operation.ADDITION));
+            } else {
+                builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", (this.isEmpowered(stack) ? ConfigConstructor.crucible_sword_empowered_damage : ConfigConstructor.crucible_sword_normal_damage) - 1, EntityAttributeModifier.Operation.ADDITION));
+            }
             builder.put(EntityAttributes.GENERIC_ATTACK_SPEED, new EntityAttributeModifier(ATTACK_SPEED_MODIFIER_ID, "Weapon modifier", this.attackSpeed, EntityAttributeModifier.Operation.ADDITION));
             attributeModifiers = builder.build();
             return attributeModifiers;
@@ -84,6 +86,9 @@ public class CrucibleSword extends SwordItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_crucible_sword) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.DOOM, stack, tooltip);
         } else {

--- a/src/main/java/net/soulsweaponry/items/DarkinBlade.java
+++ b/src/main/java/net/soulsweaponry/items/DarkinBlade.java
@@ -60,6 +60,12 @@ public class DarkinBlade extends UltraHeavyWeapon implements GeoItem {
     
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
         if (user instanceof PlayerEntity player) {
+            if(ConfigConstructor.disable_use_darkin_blade) {
+                if(ConfigConstructor.inform_player_about_disabled_use){
+                    user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+                }
+                return;
+            }
             int duration = ConfigConstructor.darkin_blade_ability_cooldown;
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -79,6 +85,9 @@ public class DarkinBlade extends UltraHeavyWeapon implements GeoItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_darkin_blade) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.OMNIVAMP, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SWORD_SLAM, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/DarkinBlade.java
+++ b/src/main/java/net/soulsweaponry/items/DarkinBlade.java
@@ -134,8 +134,8 @@ public class DarkinBlade extends UltraHeavyWeapon implements GeoItem {
     }
 
     @Override
-    public float getLaunchDivisor() {
-        return 25;
+    public float getLaunchMultiplier() {
+        return ConfigConstructor.darkin_blade_launch_multiplier;
     }
 
     @Override

--- a/src/main/java/net/soulsweaponry/items/DarkinScythePre.java
+++ b/src/main/java/net/soulsweaponry/items/DarkinScythePre.java
@@ -46,6 +46,12 @@ public class DarkinScythePre extends SoulHarvestingItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_darkin_scythe) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+            }
+            return false;
+        }
         stack.damage(1, attacker, (e) -> e.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND));
         if (target.isDead()) {
             int amount = (target instanceof BossEntity || target instanceof WitherEntity) ? 20 : 1;
@@ -137,6 +143,9 @@ public class DarkinScythePre extends SoulHarvestingItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_darkin_scythe) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.TRANSFORMATION, stack, tooltip);
         } else {

--- a/src/main/java/net/soulsweaponry/items/DarkinScythePrime.java
+++ b/src/main/java/net/soulsweaponry/items/DarkinScythePrime.java
@@ -24,6 +24,12 @@ public class DarkinScythePrime extends UmbralTrespassItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_darkin_scythe) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+            }
+            return false;
+        }
         stack.damage(1, attacker, (e) -> {
             e.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND);
         });
@@ -42,6 +48,9 @@ public class DarkinScythePrime extends UmbralTrespassItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_darkin_scythe) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.OMNIVAMP, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.UMBRAL_TRESPASS, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/DarkmoonLongbow.java
+++ b/src/main/java/net/soulsweaponry/items/DarkmoonLongbow.java
@@ -34,6 +34,12 @@ public class DarkmoonLongbow extends ModdedBow implements IKeybindAbility {
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_darkmoon_longbow) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity && !world.isClient) {
             boolean creativeAndInfinity = playerEntity.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
             ItemStack itemStack = playerEntity.getProjectileType(stack);
@@ -55,6 +61,9 @@ public class DarkmoonLongbow extends ModdedBow implements IKeybindAbility {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_darkmoon_longbow) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SLOW_PULL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.MOONLIGHT_ARROW, stack, tooltip);
@@ -72,6 +81,12 @@ public class DarkmoonLongbow extends ModdedBow implements IKeybindAbility {
 
     @Override
     public void useKeybindAbilityServer(ServerWorld world, ItemStack stack, PlayerEntity player) {
+        if(ConfigConstructor.disable_use_darkmoon_longbow) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                player.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (!player.getItemCooldownManager().isCoolingDown(this)) {
             world.playSound(null, player.getBlockPos(), SoundEvents.ENTITY_ZOMBIE_VILLAGER_CONVERTED, SoundCategory.PLAYERS, 1f, 1f);
             ArrowStormEntity entity = new ArrowStormEntity(EntityRegistry.ARROW_STORM_ENTITY, world);

--- a/src/main/java/net/soulsweaponry/items/Dawnbreaker.java
+++ b/src/main/java/net/soulsweaponry/items/Dawnbreaker.java
@@ -32,6 +32,9 @@ public class Dawnbreaker extends AbstractDawnbreaker {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_dawnbreaker) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.DAWNBREAKER, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.BLAZING_BLADE, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/DetonateGroundItem.java
+++ b/src/main/java/net/soulsweaponry/items/DetonateGroundItem.java
@@ -40,14 +40,17 @@ public abstract class DetonateGroundItem extends ChargeToUseItem {
         List<Entity> entities = world.getOtherEntities(user, box);
         for (Entity targets : entities) {
             if (targets instanceof LivingEntity livingEntity) {
-                livingEntity.damage(CustomDamageSource.create(world, CustomDamageSource.OBLITERATED, user), power + EnchantmentHelper.getAttackDamage(stack, livingEntity.getGroup()));
-                livingEntity.addVelocity(0, fallDistance/this.getLaunchDivisor(), 0);
-                if (this.shouldHeal()) user.heal(ConfigConstructor.lifesteal_item_base_healing - 1 + (ConfigConstructor.lifesteal_item_heal_scales ? power/10f : 0));
-                for (StatusEffectInstance effect : this.applyEffects()) {
-                    livingEntity.addStatusEffect(effect);
-                }
-                if (this instanceof Nightfall nightfall) {
-                    nightfall.spawnRemnant(livingEntity, user);
+                boolean canDamageTarget = livingEntity.damage(CustomDamageSource.create(world, CustomDamageSource.OBLITERATED, user), power + EnchantmentHelper.getAttackDamage(stack, livingEntity.getGroup()));
+                if(canDamageTarget || ConfigConstructor.calculated_fall_hits_immune_entities) {
+                    livingEntity.addVelocity(0, fallDistance * this.getLaunchMultiplier(), 0);
+                    if (this.shouldHeal())
+                        user.heal(ConfigConstructor.lifesteal_item_base_healing - 1 + (ConfigConstructor.lifesteal_item_heal_scales ? power / 10f : 0));
+                    for (StatusEffectInstance effect : this.applyEffects()) {
+                        livingEntity.addStatusEffect(effect);
+                    }
+                    if (this instanceof Nightfall nightfall) {
+                        nightfall.spawnRemnant(livingEntity, user);
+                    }
                 }
             }
         }
@@ -63,7 +66,7 @@ public abstract class DetonateGroundItem extends ChargeToUseItem {
 
     public abstract float getBaseExpansion();
     public abstract float getExpansionModifier();
-    public abstract float getLaunchDivisor();
+    public abstract float getLaunchMultiplier();
     public abstract boolean shouldHeal();
     public abstract StatusEffectInstance[] applyEffects();
     public abstract Map<ParticleEffect, Vec3d> getParticles();

--- a/src/main/java/net/soulsweaponry/items/DragonStaff.java
+++ b/src/main/java/net/soulsweaponry/items/DragonStaff.java
@@ -81,6 +81,12 @@ public class DragonStaff extends SwordItem {
     
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_dragon_staff) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(itemStack);
+        }
         if (!user.isSneaking()) {
             if (!user.isCreative()) user.getItemCooldownManager().set(this, this.getCooldown(itemStack)*2);
             world.playSound(user, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_ENDER_DRAGON_SHOOT, SoundCategory.NEUTRAL, 0.5f, 2/(world.getRandom().nextFloat() * 0.4F + 0.8F));
@@ -118,6 +124,9 @@ public class DragonStaff extends SwordItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_dragon_staff) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.DRAGON_STAFF, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.VENGEFUL_FOG, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/DragonslayerSwordBerserk.java
+++ b/src/main/java/net/soulsweaponry/items/DragonslayerSwordBerserk.java
@@ -40,6 +40,9 @@ public class DragonslayerSwordBerserk extends UltraHeavyWeapon implements IKeybi
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_heap_of_raw_iron) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.RAGE, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.HEAVY, stack, tooltip);
@@ -51,13 +54,18 @@ public class DragonslayerSwordBerserk extends UltraHeavyWeapon implements IKeybi
 
     @Override
     public void useKeybindAbilityServer(ServerWorld world, ItemStack stack, PlayerEntity user) {
+        if(ConfigConstructor.disable_use_heap_of_raw_iron) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+            }
+            return;
+        }
         if (!user.getItemCooldownManager().isCoolingDown(this)) {
             stack.damage(1, user, (p_220045_0_) -> p_220045_0_.sendToolBreakStatus(user.getActiveHand()));
             user.getItemCooldownManager().set(this, ConfigConstructor.heap_of_raw_iron_cooldown);
             int power = MathHelper.floor(WeaponUtil.getEnchantDamageBonus(stack));
             user.addStatusEffect(new StatusEffectInstance(EffectRegistry.BLOODTHIRSTY, 200, power));
             user.addStatusEffect(new StatusEffectInstance(StatusEffects.STRENGTH, 200, 0));
-
             world.playSound(null, user.getBlockPos(), SoundEvents.ENTITY_ENDER_DRAGON_GROWL, SoundCategory.PLAYERS, .75f, 1f);
         }
     }

--- a/src/main/java/net/soulsweaponry/items/DragonslayerSwordBerserk.java
+++ b/src/main/java/net/soulsweaponry/items/DragonslayerSwordBerserk.java
@@ -86,8 +86,8 @@ public class DragonslayerSwordBerserk extends UltraHeavyWeapon implements IKeybi
     }
 
     @Override
-    public float getLaunchDivisor() {
-        return 25;
+    public float getLaunchMultiplier() {
+        return ConfigConstructor.dragonslayer_swordspear_launch_multiplier;
     }
 
     @Override

--- a/src/main/java/net/soulsweaponry/items/DragonslayerSwordspear.java
+++ b/src/main/java/net/soulsweaponry/items/DragonslayerSwordspear.java
@@ -41,6 +41,12 @@ public class DragonslayerSwordspear extends ChargeToUseItem {
     }
 
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_dragonslayer_swordspear) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -121,6 +127,9 @@ public class DragonslayerSwordspear extends ChargeToUseItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_dragonslayer_swordspear) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.LIGHTNING_CALL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.INFINITY, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/Draugr.java
+++ b/src/main/java/net/soulsweaponry/items/Draugr.java
@@ -64,6 +64,9 @@ public class Draugr extends SwordItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_draugr) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.NIGHT_PROWLER, stack, tooltip);
         } else {

--- a/src/main/java/net/soulsweaponry/items/DraupnirSpear.java
+++ b/src/main/java/net/soulsweaponry/items/DraupnirSpear.java
@@ -54,6 +54,12 @@ public class DraupnirSpear extends ChargeToUseItem implements GeoItem, IKeybindA
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_draupnir_spear) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -104,6 +110,9 @@ public class DraupnirSpear extends ChargeToUseItem implements GeoItem, IKeybindA
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_draupnir_spear) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.INFINITY, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.DETONATE_SPEARS, stack, tooltip);
@@ -127,6 +136,12 @@ public class DraupnirSpear extends ChargeToUseItem implements GeoItem, IKeybindA
 
     @Override
     public void useKeybindAbilityServer(ServerWorld world, ItemStack stack, PlayerEntity player) {
+        if(ConfigConstructor.disable_use_draupnir_spear) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                player.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (!player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
             if (player.isSneaking()) {
                 if (!player.hasStatusEffect(EffectRegistry.COOLDOWN)) {

--- a/src/main/java/net/soulsweaponry/items/EmpoweredDawnbreaker.java
+++ b/src/main/java/net/soulsweaponry/items/EmpoweredDawnbreaker.java
@@ -63,7 +63,11 @@ public class EmpoweredDawnbreaker extends AbstractDawnbreaker implements IKeybin
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
-        if (user instanceof PlayerEntity player && !player.getItemCooldownManager().isCoolingDown(this)) {
+        if(ConfigConstructor.disable_use_empowered_dawnbreaker) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+            }
+        } else if (user instanceof PlayerEntity player && !player.getItemCooldownManager().isCoolingDown(this)) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
                 stack.damage(1, player, (p_220045_0_) -> p_220045_0_.sendToolBreakStatus(user.getActiveHand()));
@@ -103,6 +107,9 @@ public class EmpoweredDawnbreaker extends AbstractDawnbreaker implements IKeybin
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_empowered_dawnbreaker) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.DAWNBREAKER, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.BLAZING_BLADE, stack, tooltip);
@@ -148,7 +155,11 @@ public class EmpoweredDawnbreaker extends AbstractDawnbreaker implements IKeybin
 
     @Override
     public void useKeybindAbilityServer(ServerWorld world, ItemStack stack, PlayerEntity player) {
-        if (!player.getItemCooldownManager().isCoolingDown(this)) {
+        if(ConfigConstructor.disable_use_empowered_dawnbreaker) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                player.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+            }
+        } else if (!player.getItemCooldownManager().isCoolingDown(this)) {
             AbstractDawnbreaker.dawnbreakerEvent(player, player, stack);
             player.addStatusEffect(new StatusEffectInstance(EffectRegistry.VEIL_OF_FIRE, 200, MathHelper.floor(WeaponUtil.getEnchantDamageBonus(stack)/2f)));
             player.getItemCooldownManager().set(this, ConfigConstructor.empowered_dawnbreaker_ability_cooldown);

--- a/src/main/java/net/soulsweaponry/items/Featherlight.java
+++ b/src/main/java/net/soulsweaponry/items/Featherlight.java
@@ -32,6 +32,9 @@ public class Featherlight extends UltraHeavyWeapon {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_featherlight) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.FEATHERLIGHT, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.HEAVY, stack, tooltip);
@@ -47,6 +50,12 @@ public class Featherlight extends UltraHeavyWeapon {
 
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
+        if(ConfigConstructor.disable_use_featherlight) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(user.getStackInHand(hand));
+        }
         return TypedActionResult.fail(user.getStackInHand(hand));
     }
 

--- a/src/main/java/net/soulsweaponry/items/Featherlight.java
+++ b/src/main/java/net/soulsweaponry/items/Featherlight.java
@@ -61,8 +61,8 @@ public class Featherlight extends UltraHeavyWeapon {
     }
 
     @Override
-    public float getLaunchDivisor() {
-        return 20;
+    public float getLaunchMultiplier() {
+        return ConfigConstructor.featherlight_launch_multiplier;
     }
 
     @Override

--- a/src/main/java/net/soulsweaponry/items/ForlornScythe.java
+++ b/src/main/java/net/soulsweaponry/items/ForlornScythe.java
@@ -43,6 +43,11 @@ public class ForlornScythe extends SoulHarvestingItem implements GeoItem {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_forlorn_scythe) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This weapon is disabled"));
+            }
+        }
         if (!world.isClient) {
             this.detonatePrevEntity((ServerWorld) world, stack);
         }
@@ -105,6 +110,9 @@ public class ForlornScythe extends SoulHarvestingItem implements GeoItem {
 
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_forlorn_scythe) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SOUL_TRAP, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SOUL_RELEASE_WITHER, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/FreyrSword.java
+++ b/src/main/java/net/soulsweaponry/items/FreyrSword.java
@@ -47,6 +47,12 @@ public class FreyrSword extends SwordItem implements GeoItem {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_sword_of_freyr) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         FreyrSwordEntity entity = new FreyrSwordEntity(world, user, stack);
         Optional<UUID> uuid = Optional.of(entity.getUuid());
         try {
@@ -72,6 +78,9 @@ public class FreyrSword extends SwordItem implements GeoItem {
 
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_sword_of_freyr) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SUMMON_WEAPON, stack, tooltip);
         } else {

--- a/src/main/java/net/soulsweaponry/items/Frostmourne.java
+++ b/src/main/java/net/soulsweaponry/items/Frostmourne.java
@@ -40,6 +40,12 @@ public class Frostmourne extends SoulHarvestingItem implements ISummonAllies {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_frostmourne) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         int amp = MathHelper.ceil((float) WeaponUtil.getEnchantDamageBonus(stack)/2f);
         target.addStatusEffect(new StatusEffectInstance(EffectRegistry.FREEZING, 160, amp));
         return super.postHit(stack, target, attacker);
@@ -48,6 +54,12 @@ public class Frostmourne extends SoulHarvestingItem implements ISummonAllies {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_frostmourne) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         if (this.getSouls(stack) >= 5 && !world.isClient && this.canSummonEntity((ServerWorld) world, user, this.getSummonsListId())) {
             Vec3d vecBlocksAway = user.getRotationVector().multiply(3).add(user.getPos());
             BlockPos on = BlockPos.ofFloored(vecBlocksAway);
@@ -68,6 +80,9 @@ public class Frostmourne extends SoulHarvestingItem implements ISummonAllies {
 
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_frostmourne) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.FREEZE, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.PERMAFROST, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/Galeforce.java
+++ b/src/main/java/net/soulsweaponry/items/Galeforce.java
@@ -38,6 +38,12 @@ public class Galeforce extends ModdedBow implements IKeybindAbility {
     
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_galeforce) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             boolean creativeAndInfinity = playerEntity.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
             ItemStack itemStack = playerEntity.getProjectileType(stack);
@@ -58,6 +64,9 @@ public class Galeforce extends ModdedBow implements IKeybindAbility {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_galeforce) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.GALEFORCE, stack, tooltip);
         } else {
@@ -107,6 +116,12 @@ public class Galeforce extends ModdedBow implements IKeybindAbility {
 
     @Override
     public void useKeybindAbilityServer(ServerWorld world, ItemStack stack, PlayerEntity player) {
+        if(ConfigConstructor.disable_use_galeforce) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                player.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (!player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
             player.getItemCooldownManager().set(this, ConfigConstructor.galeforce_dash_cooldown);
             if (player.getAttacking() != null) {
@@ -123,6 +138,10 @@ public class Galeforce extends ModdedBow implements IKeybindAbility {
 
     @Override
     public void useKeybindAbilityClient(ClientWorld world, ItemStack stack, ClientPlayerEntity player) {
+        if(ConfigConstructor.disable_use_galeforce) {
+            //don't bother sending another message here since it's already done by the server call
+            return;
+        }
         if (!player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
             float f = player.getYaw();
             float g = player.getPitch();

--- a/src/main/java/net/soulsweaponry/items/GatlingGun.java
+++ b/src/main/java/net/soulsweaponry/items/GatlingGun.java
@@ -1,5 +1,6 @@
 package net.soulsweaponry.items;
 
+import net.minecraft.client.item.TooltipContext;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.LivingEntity;
@@ -9,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.Vec3d;
@@ -18,6 +20,9 @@ import net.soulsweaponry.entity.projectile.SilverBulletEntity;
 import net.soulsweaponry.registry.EnchantRegistry;
 import net.soulsweaponry.registry.ItemRegistry;
 import net.soulsweaponry.registry.SoundRegistry;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class GatlingGun extends GunItem {
 
@@ -48,6 +53,10 @@ public class GatlingGun extends GunItem {
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_gatling_gun) {
+            //don't bother sending a message every tick
+            return;
+        }
         if (remainingUseTicks < this.getMaxUseTime(stack) - 15 && remainingUseTicks % 4 == 0) {
             if (user instanceof PlayerEntity playerEntity) {
                 boolean bl = playerEntity.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
@@ -123,6 +132,12 @@ public class GatlingGun extends GunItem {
 
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_gatling_gun) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(itemStack);
+        }
         world.playSound(user, user.getBlockPos(), SoundRegistry.GATLING_GUN_STARTUP_EVENT, SoundCategory.PLAYERS, 1f, 1f);
         if (itemStack.getDamage() >= itemStack.getMaxDamage() - 1) {
             return TypedActionResult.fail(itemStack);
@@ -131,5 +146,13 @@ public class GatlingGun extends GunItem {
             user.setCurrentHand(hand);
             return TypedActionResult.consume(itemStack);
         }
+    }
+
+    @Override
+    public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_gatling_gun) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
+        super.appendTooltip(stack, world, tooltip, context);
     }
 }

--- a/src/main/java/net/soulsweaponry/items/GuinsoosRageblade.java
+++ b/src/main/java/net/soulsweaponry/items/GuinsoosRageblade.java
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import net.minecraft.world.World;
 import net.soulsweaponry.config.ConfigConstructor;
 
@@ -26,7 +25,13 @@ public class GuinsoosRageblade extends SwordItem {
         super(toolMaterial, ConfigConstructor.rageblade_damage, attackSpeed, settings);
     }
 
-    public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) { 
+    public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_rageblade) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         super.postHit(stack, target, attacker);
         
         if (attacker.isOnFire()) {
@@ -50,6 +55,9 @@ public class GuinsoosRageblade extends SwordItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_rageblade) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.FURY, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.HASTE, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/HolyMoonlightGreatsword.java
+++ b/src/main/java/net/soulsweaponry/items/HolyMoonlightGreatsword.java
@@ -39,6 +39,12 @@ public class HolyMoonlightGreatsword extends TrickWeapon implements IChargeNeede
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_holy_moonlight_greatsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity player) {
             int chargeTime = this.getMaxUseTime(stack) - remainingUseTicks;
             if (chargeTime >= 10) {
@@ -131,6 +137,12 @@ public class HolyMoonlightGreatsword extends TrickWeapon implements IChargeNeede
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_holy_moonlight_greatsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(itemStack);
+        }
         if (itemStack.getDamage() < itemStack.getMaxDamage() - 1 && (this.isCharged(itemStack) || user.isCreative() || user.hasStatusEffect(EffectRegistry.MOON_HERALD))) {
             user.setCurrentHand(hand);
             return TypedActionResult.success(itemStack);
@@ -150,6 +162,9 @@ public class HolyMoonlightGreatsword extends TrickWeapon implements IChargeNeede
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_holy_moonlight_greatsword) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.TRICK_WEAPON, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.NEED_CHARGE, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/HolyMoonlightSword.java
+++ b/src/main/java/net/soulsweaponry/items/HolyMoonlightSword.java
@@ -28,6 +28,8 @@ public class HolyMoonlightSword extends TrickWeapon implements IChargeNeeded {
     }
 
     private float getBonusDamage(ItemStack stack) {
+        if(ConfigConstructor.disable_use_holy_moonlight_sword)
+            return 0;
         float per = (float) this.getCharge(stack) / (float) ConfigConstructor.holy_moonlight_ability_charge_needed;
         return (float) ConfigConstructor.holy_moonlight_sword_max_bonus_damage * per;
     }

--- a/src/main/java/net/soulsweaponry/items/HunterCannon.java
+++ b/src/main/java/net/soulsweaponry/items/HunterCannon.java
@@ -1,5 +1,6 @@
 package net.soulsweaponry.items;
 
+import net.minecraft.client.item.TooltipContext;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.player.PlayerEntity;
@@ -9,6 +10,7 @@ import net.minecraft.particle.ParticleTypes;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.MathHelper;
@@ -18,6 +20,9 @@ import net.soulsweaponry.config.ConfigConstructor;
 import net.soulsweaponry.entity.projectile.Cannonball;
 import net.soulsweaponry.registry.EnchantRegistry;
 import net.soulsweaponry.registry.ItemRegistry;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class HunterCannon extends GunItem {
 
@@ -48,6 +53,12 @@ public class HunterCannon extends GunItem {
 
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_hunter_cannon) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         boolean bl = user.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
         ItemStack itemStack = user.getProjectileType(stack);
         int bulletsNeeded = this.bulletsNeeded();
@@ -104,5 +115,12 @@ public class HunterCannon extends GunItem {
             return TypedActionResult.success(stack, world.isClient());
         }
         return TypedActionResult.fail(stack); 
+    }
+    @Override
+    public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_hunter_cannon) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
+        super.appendTooltip(stack, world, tooltip, context);
     }
 }

--- a/src/main/java/net/soulsweaponry/items/HunterPistol.java
+++ b/src/main/java/net/soulsweaponry/items/HunterPistol.java
@@ -1,5 +1,6 @@
 package net.soulsweaponry.items;
 
+import net.minecraft.client.item.TooltipContext;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.player.PlayerEntity;
@@ -9,6 +10,7 @@ import net.minecraft.particle.ParticleTypes;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.Vec3d;
@@ -17,6 +19,9 @@ import net.soulsweaponry.config.ConfigConstructor;
 import net.soulsweaponry.entity.projectile.SilverBulletEntity;
 import net.soulsweaponry.registry.EnchantRegistry;
 import net.soulsweaponry.registry.ItemRegistry;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class HunterPistol extends GunItem {
 
@@ -47,6 +52,12 @@ public class HunterPistol extends GunItem {
 
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_hunter_pistol) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         boolean bl = user.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
         ItemStack itemStack = user.getProjectileType(stack);
         if (!itemStack.isEmpty() || bl) {
@@ -92,5 +103,12 @@ public class HunterPistol extends GunItem {
             return TypedActionResult.success(stack, world.isClient());
         }
         return TypedActionResult.fail(stack); 
+    }
+    @Override
+    public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_hunter_pistol) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
+        super.appendTooltip(stack, world, tooltip, context);
     }
 }

--- a/src/main/java/net/soulsweaponry/items/KrakenSlayer.java
+++ b/src/main/java/net/soulsweaponry/items/KrakenSlayer.java
@@ -27,6 +27,12 @@ public class KrakenSlayer extends ModdedBow {
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_kraken_slayer_bow) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             boolean creativeAndInfinity = playerEntity.getAbilities().creativeMode || EnchantmentHelper.getLevel(Enchantments.INFINITY, stack) > 0;
             ItemStack itemStack = playerEntity.getProjectileType(stack);
@@ -64,6 +70,9 @@ public class KrakenSlayer extends ModdedBow {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_kraken_slayer_bow) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.FAST_PULL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.THIRD_SHOT, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/KrakenSlayerCrossbow.java
+++ b/src/main/java/net/soulsweaponry/items/KrakenSlayerCrossbow.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.soulsweaponry.config.ConfigConstructor;
 import net.soulsweaponry.entity.projectile.KrakenSlayerProjectile;
@@ -22,6 +23,17 @@ public class KrakenSlayerCrossbow extends ModdedCrossbow {
 
     public KrakenSlayerCrossbow(Settings settings) {
         super(settings);
+    }
+
+    @Override
+    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
+        if(ConfigConstructor.disable_use_kraken_slayer_crossbow) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(user.getStackInHand(hand));
+        }
+        return super.use(world, user, hand);
     }
 
     @Override
@@ -95,6 +107,9 @@ public class KrakenSlayerCrossbow extends ModdedCrossbow {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_kraken_slayer_crossbow) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.FAST_PULL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.THIRD_SHOT, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/LeviathanAxe.java
+++ b/src/main/java/net/soulsweaponry/items/LeviathanAxe.java
@@ -52,6 +52,12 @@ public class LeviathanAxe extends AxeItem implements GeoItem {
     
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_leviathan_axe) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         int sharpness = MathHelper.floor(EnchantmentHelper.getAttackDamage(stack, target.getGroup()));
         target.addStatusEffect(new StatusEffectInstance(EffectRegistry.FREEZING, 200, sharpness));
         return super.postHit(stack, target, attacker);
@@ -59,6 +65,12 @@ public class LeviathanAxe extends AxeItem implements GeoItem {
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_leviathan_axe) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         super.onStoppedUsing(stack, world, user, remainingUseTicks);
         if (user instanceof PlayerEntity playerEntity) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
@@ -117,6 +129,9 @@ public class LeviathanAxe extends AxeItem implements GeoItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_leviathan_axe) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.FREEZE, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.PERMAFROST, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/LichBane.java
+++ b/src/main/java/net/soulsweaponry/items/LichBane.java
@@ -26,6 +26,12 @@ public class LichBane extends SwordItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_lich_bane) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         super.postHit(stack, target, attacker);
         if (target.getHealth() > target.getMaxHealth()/3 && target.getHealth() > this.getBonusMagicDamage(stack)) {
             ((LivingEntityInvoker)target).invokeApplyDamage(attacker.getWorld().getDamageSources().magic(), this.getBonusMagicDamage(stack));
@@ -40,6 +46,9 @@ public class LichBane extends SwordItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_lich_bane) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.MAGIC_DAMAGE, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.BLAZING_BLADE, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/MasterSword.java
+++ b/src/main/java/net/soulsweaponry/items/MasterSword.java
@@ -25,6 +25,12 @@ public class MasterSword extends ChargeToUseItem {
     }
 
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_master_sword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -42,6 +48,9 @@ public class MasterSword extends ChargeToUseItem {
     
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_master_sword) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SKYWARD_STRIKES, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.RIGHTEOUS, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/Mjolnir.java
+++ b/src/main/java/net/soulsweaponry/items/Mjolnir.java
@@ -57,6 +57,12 @@ public class Mjolnir extends ChargeToUseItem implements GeoItem {
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_mjolnir) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         int i = this.getMaxUseTime(stack) - remainingUseTicks;
         if (user instanceof PlayerEntity player && i >= 10) {
             int cooldown = 0;
@@ -177,7 +183,11 @@ public class Mjolnir extends ChargeToUseItem implements GeoItem {
         Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers;
         if (slot == EquipmentSlot.MAINHAND) {
             Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
-            builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", this.isRaining(stack) ? ConfigConstructor.mjolnir_rain_bonus_damage - 1 + ConfigConstructor.mjolnir_damage : ConfigConstructor.mjolnir_damage - 1, EntityAttributeModifier.Operation.ADDITION));
+            if(ConfigConstructor.disable_use_mjolnir) {
+                builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", ConfigConstructor.mjolnir_damage - 1, EntityAttributeModifier.Operation.ADDITION));
+            } else {
+                builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", this.isRaining(stack) ? ConfigConstructor.mjolnir_rain_bonus_damage - 1 + ConfigConstructor.mjolnir_damage : ConfigConstructor.mjolnir_damage - 1, EntityAttributeModifier.Operation.ADDITION));
+            }
             builder.put(EntityAttributes.GENERIC_ATTACK_SPEED, new EntityAttributeModifier(ATTACK_SPEED_MODIFIER_ID, "Weapon modifier", -2.8D, EntityAttributeModifier.Operation.ADDITION));
             attributeModifiers = builder.build();
             return attributeModifiers;
@@ -188,6 +198,9 @@ public class Mjolnir extends ChargeToUseItem implements GeoItem {
 
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_mjolnir) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.MJOLNIR_LIGHTNING, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.THROW_LIGHTNING, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/MoonlightGreatsword.java
+++ b/src/main/java/net/soulsweaponry/items/MoonlightGreatsword.java
@@ -30,6 +30,12 @@ public class MoonlightGreatsword extends ChargeToUseItem {
     }
 
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_moonlight_greatsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -54,6 +60,9 @@ public class MoonlightGreatsword extends ChargeToUseItem {
     
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_moonlight_greatsword) {
+            tooltip.add(Text.translatable("tooltip.soulsweapons.disabled"));
+        }
         if (Screen.hasShiftDown()) {
             if (this instanceof BluemoonGreatsword) {
                 WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.NEED_CHARGE, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/MoonlightShortsword.java
+++ b/src/main/java/net/soulsweaponry/items/MoonlightShortsword.java
@@ -34,6 +34,12 @@ public class MoonlightShortsword extends SwordItem {
     }
 
     public static void summonSmallProjectile(World world, PlayerEntity user) {
+        if(ConfigConstructor.disable_use_moonlight_shortsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         for (Hand hand : Hand.values()) {
             ItemStack itemStack = user.getStackInHand(hand);
             if (!user.getItemCooldownManager().isCoolingDown(WeaponRegistry.MOONLIGHT_SHORTSWORD) && itemStack.isOf(WeaponRegistry.MOONLIGHT_SHORTSWORD)
@@ -71,6 +77,12 @@ public class MoonlightShortsword extends SwordItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_moonlight_shortsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         stack.damage(1, attacker, e -> e.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND));
         return super.postHit(stack, target, attacker);
     }

--- a/src/main/java/net/soulsweaponry/items/Nightfall.java
+++ b/src/main/java/net/soulsweaponry/items/Nightfall.java
@@ -56,6 +56,12 @@ public class Nightfall extends UltraHeavyWeapon implements GeoItem, IKeybindAbil
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_nightfall) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity player) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -82,13 +88,19 @@ public class Nightfall extends UltraHeavyWeapon implements GeoItem, IKeybindAbil
     }
 
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_nightfall) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         this.spawnRemnant(target, attacker);
         this.gainStrength(attacker);
         return super.postHit(stack, target, attacker);
     }
 
     public void spawnRemnant(LivingEntity target, LivingEntity attacker) {
-        if (target.isUndead() && target.isDead() && attacker instanceof PlayerEntity) {
+        if (target.isUndead() && target.isDead() && attacker instanceof PlayerEntity && !ConfigConstructor.disable_use_nightfall) {
             double chance = new Random().nextDouble();
             World world = attacker.getEntityWorld();
             if (!world.isClient && this.canSummonEntity((ServerWorld) world, attacker, this.getSummonsListId()) && chance < ConfigConstructor.nightfall_summon_chance) {
@@ -132,6 +144,9 @@ public class Nightfall extends UltraHeavyWeapon implements GeoItem, IKeybindAbil
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_nightfall) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SUMMON_GHOST, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SHIELD, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/Nightfall.java
+++ b/src/main/java/net/soulsweaponry/items/Nightfall.java
@@ -172,8 +172,8 @@ public class Nightfall extends UltraHeavyWeapon implements GeoItem, IKeybindAbil
     }
 
     @Override
-    public float getLaunchDivisor() {
-        return 30;
+    public float getLaunchMultiplier() {
+        return ConfigConstructor.nightfall_launch_multiplier;
     }
 
     @Override

--- a/src/main/java/net/soulsweaponry/items/NightsEdgeItem.java
+++ b/src/main/java/net/soulsweaponry/items/NightsEdgeItem.java
@@ -35,6 +35,9 @@ public class NightsEdgeItem extends ChargeToUseItem implements IKeybindAbility {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_nights_edge) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.NIGHTS_EDGE, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.BLIGHT, stack, tooltip);
@@ -46,6 +49,12 @@ public class NightsEdgeItem extends ChargeToUseItem implements IKeybindAbility {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_nights_edge) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         if (target.hasStatusEffect(EffectRegistry.BLIGHT)) {
             int amp = target.getStatusEffect(EffectRegistry.BLIGHT).getAmplifier();
             target.addStatusEffect(new StatusEffectInstance(EffectRegistry.BLIGHT, 60, amp + 1));
@@ -60,6 +69,12 @@ public class NightsEdgeItem extends ChargeToUseItem implements IKeybindAbility {
 
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_nights_edge) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity player && !player.getItemCooldownManager().isCoolingDown(this)) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -72,6 +87,12 @@ public class NightsEdgeItem extends ChargeToUseItem implements IKeybindAbility {
 
     @Override
     public void useKeybindAbilityServer(ServerWorld world, ItemStack stack, PlayerEntity player) {
+        if(ConfigConstructor.disable_use_nights_edge) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                player.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (!player.getItemCooldownManager().isCoolingDown(this)) {
             this.castSpell(player, world, stack, true);
             player.getItemCooldownManager().set(this, ConfigConstructor.nights_edge_ability_cooldown);

--- a/src/main/java/net/soulsweaponry/items/PureMoonlightGreatsword.java
+++ b/src/main/java/net/soulsweaponry/items/PureMoonlightGreatsword.java
@@ -25,6 +25,12 @@ public class PureMoonlightGreatsword extends ChargeToUseItem {
     }
 
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_pure_moonlight_greatsword) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         if (user instanceof PlayerEntity playerEntity) {
             int i = this.getMaxUseTime(stack) - remainingUseTicks;
             if (i >= 10) {
@@ -46,6 +52,9 @@ public class PureMoonlightGreatsword extends ChargeToUseItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_pure_moonlight_greatsword) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.TRIPLE_MOONLIGHT, stack, tooltip);
         } else {

--- a/src/main/java/net/soulsweaponry/items/ShadowAssassinScythe.java
+++ b/src/main/java/net/soulsweaponry/items/ShadowAssassinScythe.java
@@ -37,6 +37,12 @@ public class ShadowAssassinScythe extends UmbralTrespassItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_shadow_assassin_scythe) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         stack.damage(1, attacker, (e) -> e.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND));
         if (attacker instanceof PlayerEntity player) {
             var cooldownManager = player.getItemCooldownManager();
@@ -58,7 +64,7 @@ public class ShadowAssassinScythe extends UmbralTrespassItem {
     }
 
     private boolean canGetBonus(ItemStack stack) {
-        if (stack.hasNbt() && stack.getNbt().contains(HAS_EFFECT)) {
+        if (stack.hasNbt() && stack.getNbt().contains(HAS_EFFECT) && !ConfigConstructor.disable_use_shadow_assassin_scythe) {
             return stack.getNbt().getBoolean(HAS_EFFECT);
         }
         return false;
@@ -79,6 +85,9 @@ public class ShadowAssassinScythe extends UmbralTrespassItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_shadow_assassin_scythe){
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SHADOW_STEP, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.UMBRAL_TRESPASS, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/Skofnung.java
+++ b/src/main/java/net/soulsweaponry/items/Skofnung.java
@@ -42,6 +42,12 @@ public class Skofnung extends SwordItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        if(ConfigConstructor.disable_use_skofnung) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                attacker.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return false;
+        }
         int duration = ConfigConstructor.skofnung_disable_heal_duration + (WeaponUtil.getEnchantDamageBonus(stack) * 40);
         target.addStatusEffect(new StatusEffectInstance(EffectRegistry.DISABLE_HEAL, duration, 0));
         if (isEmpowered(stack)) {
@@ -63,7 +69,11 @@ public class Skofnung extends SwordItem {
         Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers;
         if (slot == EquipmentSlot.MAINHAND && isEmpowered(stack)) {
             Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
-            builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", ConfigConstructor.skofnung_damage + (ConfigConstructor.skofnung_bonus_damage - 1), EntityAttributeModifier.Operation.ADDITION));
+            if(ConfigConstructor.disable_use_skofnung){
+                builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", ConfigConstructor.skofnung_damage + (ConfigConstructor.skofnung_bonus_damage - 1), EntityAttributeModifier.Operation.ADDITION));
+            } else {
+                builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, "Weapon modifier", ConfigConstructor.skofnung_damage + (ConfigConstructor.skofnung_bonus_damage - 1), EntityAttributeModifier.Operation.ADDITION));
+            }
             builder.put(EntityAttributes.GENERIC_ATTACK_SPEED, new EntityAttributeModifier(ATTACK_SPEED_MODIFIER_ID, "Weapon modifier", -2.4D, EntityAttributeModifier.Operation.ADDITION));
             attributeModifiers = builder.build();
             return attributeModifiers;
@@ -94,6 +104,9 @@ public class Skofnung extends SwordItem {
     
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_skofnung) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.DISABLE_HEAL, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SHARPEN, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/SkofnungStone.java
+++ b/src/main/java/net/soulsweaponry/items/SkofnungStone.java
@@ -29,6 +29,12 @@ public class SkofnungStone extends Item {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack stoneStack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_skofnung_stone) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stoneStack);
+        }
         boolean shouldDamage = false;
         for (Hand offHand : Hand.values()) {
             ItemStack swordStack = user.getStackInHand(offHand);

--- a/src/main/java/net/soulsweaponry/items/SoulReaper.java
+++ b/src/main/java/net/soulsweaponry/items/SoulReaper.java
@@ -50,6 +50,12 @@ public class SoulReaper extends SoulHarvestingItem implements GeoItem, ISummonAl
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity player, Hand hand) {
 		ItemStack stack = player.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_soul_reaper) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                player.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(stack);
+        }
         if (stack.hasNbt() && stack.getNbt().contains(KILLS)) {
             int power = this.getSouls(stack);
             if (player.isCreative()) power = player.getRandom().nextBetween(5, 50);
@@ -89,6 +95,9 @@ public class SoulReaper extends SoulHarvestingItem implements GeoItem, ISummonAl
 
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_soul_reaper) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SOUL_TRAP, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SOUL_RELEASE, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/items/WhirligigSawblade.java
+++ b/src/main/java/net/soulsweaponry/items/WhirligigSawblade.java
@@ -42,6 +42,12 @@ public class WhirligigSawblade extends ChargeToUseItem {
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
+        if(ConfigConstructor.disable_use_whirligig_sawblade) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return;
+        }
         Vec3d vecBlocksAway = user.getRotationVector().multiply(5).add((user).getPos());
         Box chunkBox = new Box(user.getX(), user.getY(), user.getZ(), vecBlocksAway.x, vecBlocksAway.y + 1, vecBlocksAway.z);
         List<Entity> nearbyEntities = world.getOtherEntities(user, chunkBox);
@@ -83,6 +89,9 @@ public class WhirligigSawblade extends ChargeToUseItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_whirligig_sawblade) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.SAWBLADE, stack, tooltip);
         } else {

--- a/src/main/java/net/soulsweaponry/items/WitheredWabbajack.java
+++ b/src/main/java/net/soulsweaponry/items/WitheredWabbajack.java
@@ -44,6 +44,12 @@ public class WitheredWabbajack extends SwordItem {
 
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+        if(ConfigConstructor.disable_use_withered_wabbajack) {
+            if(ConfigConstructor.inform_player_about_disabled_use){
+                user.sendMessage(Text.translatableWithFallback("soulsweapons.weapon.useDisabled","This item is disabled"));
+            }
+            return TypedActionResult.fail(itemStack);
+        }
         user.getItemCooldownManager().set(this, 1);
         world.playSound(user, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_ENDER_DRAGON_SHOOT, SoundCategory.NEUTRAL, 0.5f, 2/(world.getRandom().nextFloat() * 0.4F + 0.8F));
         if (!world.isClient) {
@@ -194,6 +200,9 @@ public class WitheredWabbajack extends SwordItem {
 
     @Override
     public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+        if(ConfigConstructor.disable_use_withered_wabbajack) {
+            tooltip.add(Text.translatableWithFallback("tooltip.soulsweapons.disabled","Disabled"));
+        }
         if (Screen.hasShiftDown()) {
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.WABBAJACK, stack, tooltip);
             WeaponUtil.addAbilityTooltip(WeaponUtil.TooltipAbilities.LUCK_BASED, stack, tooltip);

--- a/src/main/java/net/soulsweaponry/networking/C2S/SwitchTrickWeaponC2S.java
+++ b/src/main/java/net/soulsweaponry/networking/C2S/SwitchTrickWeaponC2S.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import static net.soulsweaponry.util.WeaponUtil.TRICK_WEAPONS;
 
 public class SwitchTrickWeaponC2S {
-
+//todo let users disable trick weapons
     public static void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender sender) {
         server.execute(() -> {
             ServerWorld serverWorld = Iterables.tryFind(server.getWorlds(), (element) -> element == player.getWorld()).orNull();

--- a/src/main/resources/assets/soulsweapons/lang/en_us.json
+++ b/src/main/resources/assets/soulsweapons/lang/en_us.json
@@ -1,4 +1,8 @@
 {
+    "soulsweapons.midnightconfig.recipeComment": "Disable recipes for weapons",
+    "soulsweapons.midnightconfig.useComment": "Disable usage of weapons",
+    "soulsweapons.weapon.useDisabled": "§4This item is disabled!§r",
+
     "block.soulsweapons.moonstone_block": "Block of Moonstone",
     "block.soulsweapons.moonstone_ore": "Moonstone Ore",
     "block.soulsweapons.moonstone_ore_deepslate": "Deepslate Moonstone Ore",
@@ -320,6 +324,7 @@
 
     "tooltip.soulsweapons.shift": "Hold [§eSHIFT§r] for Info",
     "tooltip.soulsweapons.control": "Hold [§eCTRL§r] for Lore",
+    "tooltip.soulsweapons.disabled": "§4Disabled§r",
     "tooltip.soulsweapons.magic_damage": "Spellblade",
     "tooltip.soulsweapons.magic_damage_description_1": "- While the target has over §c33% Health§r, deal",
     "tooltip.soulsweapons.magic_damage_description_2": "bonus §9Magic Damage§r based on §6Fire Aspect§r",


### PR DESCRIPTION
- Fixed server crashes in boss fights
- Calculated Fall status effect changes
  - Each weapon with the effect can now be tweaked in the config file
  - Converted from a divisor to a multiplier to make it easy to disable (multiply by zero instead of divide by a really high number).
  - Entities that are immune to damage are now immune to calculated fall by default (can be disabled in config)