### PR TITLE
"Fix: Boss explosive knockback and add boss damage gating"

### DIFF
--- a/src/main/java/net/soulsweaponry/entity/projectile/SilverBulletEntity.java
+++ b/src/main/java/net/soulsweaponry/entity/projectile/SilverBulletEntity.java
@@ -282,9 +282,49 @@ public class SilverBulletEntity extends ModPersistentProjectile implements GeoEn
                 }
             }
         }
-        if (this.explosionPower > 0f && !this.getWorld().isClient) {//TODO with every gun enchant and ethereal (not ricochet, it works fine) boss loot wont drop due to the explosions killing the boss
-            ParticleHandler.particleOutburst(this.getWorld(), 30, this.getX(), this.getY(), this.getZ(), ParticleTypes.SOUL, new Vec3d(1, 1 ,1), 0.6f);
-            this.getWorld().createExplosion(this.getOwner(), this.getX(), this.getY(), this.getZ(), this.explosionPower, ConfigConstructor.explosive_rounds_enchant_destroys_blocks ? World.ExplosionSourceType.MOB : World.ExplosionSourceType.TRIGGER);
+//        if (this.explosionPower > 0f && !this.getWorld().isClient) {//TODO with every gun enchant and ethereal (not ricochet, it works fine) boss loot wont drop due to the explosions killing the boss
+//            ParticleHandler.particleOutburst(this.getWorld(), 30, this.getX(), this.getY(), this.getZ(), ParticleTypes.SOUL, new Vec3d(1, 1 ,1), 0.6f);
+//            this.getWorld().createExplosion(this.getOwner(), this.getX(), this.getY(), this.getZ(), this.explosionPower, ConfigConstructor.explosive_rounds_enchant_destroys_blocks ? World.ExplosionSourceType.MOB : World.ExplosionSourceType.TRIGGER);
+//        }
+//        this.discard();
+
+        //Fix: bosses don't get explode dmg and ignore aoe dmg if explode on mobs
+        //cons: cannot destroy block (even turn on)
+        if (this.explosionPower > 0f && !this.getWorld().isClient) {
+            ParticleHandler.particleOutburst(this.getWorld(), 30, this.getX(), this.getY(), this.getZ(), ParticleTypes.EXPLOSION, new Vec3d(1, 1 ,1), 0.6f);
+            this.getWorld().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.ENTITY_GENERIC_EXPLODE.value(), SoundCategory.PLAYERS, 1.0f, 1.0f);
+            float radius = this.explosionPower * 2.0f;
+            Box blastBox = this.getBoundingBox().expand(radius);
+
+            List<LivingEntity> targets = this.getWorld().getEntitiesByClass(LivingEntity.class, blastBox, e -> e.isAlive() && e != this.getOwner());
+
+            for (LivingEntity target : targets) {
+                // HP > 200 (is Boss from any mod)
+                if (target.getMaxHealth() >= 200.0f) {
+                    continue;
+                }
+
+                // Calculate distance for explod and damage
+                double dist = Math.sqrt(this.squaredDistanceTo(target));
+                if (dist <= radius) {
+                    float damageMultiplier = (float) (1.0 - (dist / radius));
+
+                    // Damage
+                    float aoeDamage = this.explosionPower * 4.0f * damageMultiplier;
+                    target.damage(this.getDamageSources().thrown(this, this.getOwner()), aoeDamage);
+
+                    // Knockback
+                    double kbStrength = this.explosionPower * 0.3 * damageMultiplier;
+                    Vec3d pushDir = target.getPos().subtract(this.getPos()).normalize().multiply(kbStrength);
+                    if (pushDir.lengthSquared() > 0) {
+                        pushDir = pushDir.normalize().multiply(kbStrength);
+                    } else {
+                        pushDir = new Vec3d(0, kbStrength, 0); // Đẩy thẳng lên trời nếu trùng vị trí
+                    }
+                    target.addVelocity(pushDir.x, pushDir.y + 0.2, pushDir.z);
+                    target.velocityModified = true;
+                }
+            }
         }
         this.discard();
     }

--- a/src/main/java/net/soulsweaponry/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/soulsweaponry/mixin/LivingEntityMixin.java
@@ -50,13 +50,64 @@ public class LivingEntityMixin {
     /*
      * NB! Only called if the damage is bigger than 0 (decimals count)
      */
+//    @ModifyReturnValue(method = "modifyAppliedDamage", at = @At("TAIL"))
+//    private float modifyDamageReturnValue(float originalAmount) {
+//        LivingEntity entity = (LivingEntity) (Object) this;
+//        if (capturedDamageSource != null) {
+//            return ModifyDamageUtil.modifyDamageTakenTail(entity, originalAmount, capturedDamageSource);
+//        }
+//        return originalAmount;
+//    }
+
+    // Dmg Cap (25%) + Gating (in 10 tick = 0.5s) FOR BOSS (Boss Entity and any Mob with >= 200 HP)
     @ModifyReturnValue(method = "modifyAppliedDamage", at = @At("TAIL"))
     private float modifyDamageReturnValue(float originalAmount) {
         LivingEntity entity = (LivingEntity) (Object) this;
+        float finalAmount = originalAmount;
+
         if (capturedDamageSource != null) {
-            return ModifyDamageUtil.modifyDamageTakenTail(entity, originalAmount, capturedDamageSource);
+            finalAmount = ModifyDamageUtil.modifyDamageTakenTail(entity, finalAmount, capturedDamageSource);
         }
-        return originalAmount;
+
+        if (entity instanceof net.soulsweaponry.entity.mobs.BossEntity || entity.getMaxHealth() >= 200.0f) {
+
+            float maxDamageLimit = entity.getMaxHealth() * 0.25f;
+
+            //CASE 1: POSTURE BREAK
+            if (entity.hasStatusEffect(EffectRegistry.POSTURE_BREAK)) {
+                this.souls_wasPostureBroken = true;
+
+                if (this.souls_damageTakenDuringPostureBreak + finalAmount > maxDamageLimit) {
+                    finalAmount = maxDamageLimit - this.souls_damageTakenDuringPostureBreak;
+                    if (finalAmount <= 0f) return 0f;
+                }
+                this.souls_damageTakenDuringPostureBreak += finalAmount;
+            }
+            //CASE 2: NORMAL
+            else {
+                if (this.souls_wasPostureBroken) {
+                    this.souls_damageTakenDuringPostureBreak = 0f;
+                    this.souls_wasPostureBroken = false;
+                    this.souls_damageTakenThisWindow = 0f;
+                    this.souls_lastDamageWindowTick = entity.age;
+                }
+
+                int currentTick = entity.age;
+                //10 tick
+                if (currentTick - this.souls_lastDamageWindowTick > 10) {
+                    this.souls_damageTakenThisWindow = 0f;
+                    this.souls_lastDamageWindowTick = currentTick;
+                }
+
+                if (this.souls_damageTakenThisWindow + finalAmount > maxDamageLimit) {
+                    finalAmount = maxDamageLimit - this.souls_damageTakenThisWindow;
+                    if (finalAmount <= 0f) return 0f;
+                }
+                this.souls_damageTakenThisWindow += finalAmount;
+            }
+        }
+
+        return finalAmount;
     }
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
@@ -248,4 +299,14 @@ public class LivingEntityMixin {
             abilities.getAbilities().forEach(a -> a.onEquipStack(entity, slot, oldStack, newStack));
         }
     }
+
+    //Damage Cap + Gating
+    @Unique
+    private int souls_lastDamageWindowTick = 0;
+    @Unique
+    private float souls_damageTakenThisWindow = 0f;
+    @Unique
+    private float souls_damageTakenDuringPostureBreak = 0f;
+    @Unique
+    private boolean souls_wasPostureBroken = false;
 }


### PR DESCRIPTION
(Sorry, My english is bad so i Use AI to write this)
Hi, I've made some adjustments to fix the explosive knockback bug on bosses and implemented a damage gating mechanic to prevent bosses from being one-shot by multi-hit weapons (like the Blunderbuss) or overlapping mod interactions.

1. Explosive Rounds Fix (SilverBulletEntity.java)

The Issue: As noted in the TODO comments, the createExplosion method caused bosses to be massively knocked back and killed by AoE from nearby mobs, which also broke their loot tables.

The Fix: Replaced the default createExplosion with a custom AoE logic. The explosion now checks for target.getMaxHealth() >= 200.0f (or BossEntity). If the target is a boss, it completely ignores the AoE blast damage and knockback. Direct hit damage from the projectile is still applied normally via super.onEntityHit().

2. Boss Damage Cap & Gating (LivingEntityMixin.java)

The Issue: Bosses (especially Undead ones) were taking extreme burst damage (e.g., 351+ damage instantly) when shot by shotgun-style weapons at close range, especially during a Posture Break.

The Fix: Implemented a damage cap exclusively for Bosses (or entities with >= 200 Max HP) via @ModifyReturnValue in modifyAppliedDamage.

Normal State: Bosses cannot take more than 25% of their Max HP within a 0.5-second window (10 ticks). Multi-hit projectiles hitting simultaneously will be cleanly truncated to the cap.

Posture Break State: The 25% Max HP cap is strictly locked for the entire duration of the stun. Once the boss recovers from the Posture Break, the damage trackers are instantly reset to ensure a smooth transition to the next phase.