### PR TITLE
Fix boss breaking bedrock for Returning Knight and MoonKnight

### DIFF
--- a/src/main/java/net/soulsweaponry/entity/mobs/Moonknight.java
+++ b/src/main/java/net/soulsweaponry/entity/mobs/Moonknight.java
@@ -299,8 +299,13 @@ public class Moonknight extends BossEntity implements GeoEntity {
                     for (int l = -3; l <= 3; ++l) {
                         for (int m = -3; m <= 3; ++m) {
                             for (int n = 0; n <= 8; ++n) {
-                                if (!(this.getWorld().getBlockState(new BlockPos(j + l, i + n, k + m)).getBlock() instanceof BlockWithEntity)) {
-                                    this.getWorld().breakBlock(new BlockPos(j + l, i + n, k + m), true);
+                                //Condition: not WITHER_IMMUNE Block
+                                BlockPos targetPos = new BlockPos(j + l, i + n, k + m);
+                                net.minecraft.block.BlockState targetState = this.getWorld().getBlockState(targetPos);
+                                if (!(targetState.getBlock() instanceof BlockWithEntity)
+                                        && targetState.getHardness(this.getWorld(), targetPos) >= 0.0F
+                                        && !targetState.isIn(net.minecraft.registry.tag.BlockTags.WITHER_IMMUNE)) {
+                                    this.getWorld().breakBlock(targetPos, true);
                                 }
                             }
                         }

--- a/src/main/java/net/soulsweaponry/entity/mobs/ReturningKnight.java
+++ b/src/main/java/net/soulsweaponry/entity/mobs/ReturningKnight.java
@@ -341,8 +341,13 @@ public class ReturningKnight extends BossEntity implements GeoEntity {
                     for (int l = -3; l <= 3; ++l) {
                         for (int m = -3; m <= 3; ++m) {
                             for (int n = 0; n <= 8; ++n) {
-                                if (!(this.getWorld().getBlockState(new BlockPos(j + l, i + n, k + m)).getBlock() instanceof BlockWithEntity)) {
-                                    this.getWorld().breakBlock(new BlockPos(j + l, i + n, k + m), true);
+                                //Condition: not WITHER_IMMUNE Block
+                                BlockPos targetPos = new BlockPos(j + l, i + n, k + m);
+                                net.minecraft.block.BlockState targetState = this.getWorld().getBlockState(targetPos);
+                                if (!(targetState.getBlock() instanceof BlockWithEntity)
+                                        && targetState.getHardness(this.getWorld(), targetPos) >= 0.0F
+                                        && !targetState.isIn(net.minecraft.registry.tag.BlockTags.WITHER_IMMUNE)) {
+                                    this.getWorld().breakBlock(targetPos, true);
                                 }
                             }
                         }

--- a/src/main/java/net/soulsweaponry/entity/projectile/SilverBulletEntity.java
+++ b/src/main/java/net/soulsweaponry/entity/projectile/SilverBulletEntity.java
@@ -282,9 +282,49 @@ public class SilverBulletEntity extends ModPersistentProjectile implements GeoEn
                 }
             }
         }
-        if (this.explosionPower > 0f && !this.getWorld().isClient) {//TODO with every gun enchant and ethereal (not ricochet, it works fine) boss loot wont drop due to the explosions killing the boss
-            ParticleHandler.particleOutburst(this.getWorld(), 30, this.getX(), this.getY(), this.getZ(), ParticleTypes.SOUL, new Vec3d(1, 1 ,1), 0.6f);
-            this.getWorld().createExplosion(this.getOwner(), this.getX(), this.getY(), this.getZ(), this.explosionPower, ConfigConstructor.explosive_rounds_enchant_destroys_blocks ? World.ExplosionSourceType.MOB : World.ExplosionSourceType.TRIGGER);
+//        if (this.explosionPower > 0f && !this.getWorld().isClient) {//TODO with every gun enchant and ethereal (not ricochet, it works fine) boss loot wont drop due to the explosions killing the boss
+//            ParticleHandler.particleOutburst(this.getWorld(), 30, this.getX(), this.getY(), this.getZ(), ParticleTypes.SOUL, new Vec3d(1, 1 ,1), 0.6f);
+//            this.getWorld().createExplosion(this.getOwner(), this.getX(), this.getY(), this.getZ(), this.explosionPower, ConfigConstructor.explosive_rounds_enchant_destroys_blocks ? World.ExplosionSourceType.MOB : World.ExplosionSourceType.TRIGGER);
+//        }
+//        this.discard();
+
+        //Fix: bosses don't get explode dmg and ignore aoe dmg if explode on mobs
+        //cons: cannot destroy block (even turn on)
+        if (this.explosionPower > 0f && !this.getWorld().isClient) {
+            ParticleHandler.particleOutburst(this.getWorld(), 30, this.getX(), this.getY(), this.getZ(), ParticleTypes.EXPLOSION, new Vec3d(1, 1 ,1), 0.6f);
+            this.getWorld().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.ENTITY_GENERIC_EXPLODE.value(), SoundCategory.PLAYERS, 1.0f, 1.0f);
+            float radius = this.explosionPower * 2.0f;
+            Box blastBox = this.getBoundingBox().expand(radius);
+
+            List<LivingEntity> targets = this.getWorld().getEntitiesByClass(LivingEntity.class, blastBox, e -> e.isAlive() && e != this.getOwner());
+
+            for (LivingEntity target : targets) {
+                // HP > 200 (is Boss from any mod)
+                if (target.getMaxHealth() >= 200.0f) {
+                    continue;
+                }
+
+                // Calculate distance for explod and damage
+                double dist = Math.sqrt(this.squaredDistanceTo(target));
+                if (dist <= radius) {
+                    float damageMultiplier = (float) (1.0 - (dist / radius));
+
+                    // Damage
+                    float aoeDamage = this.explosionPower * 4.0f * damageMultiplier;
+                    target.damage(this.getDamageSources().thrown(this, this.getOwner()), aoeDamage);
+
+                    // Knockback
+                    double kbStrength = this.explosionPower * 0.3 * damageMultiplier;
+                    Vec3d pushDir = target.getPos().subtract(this.getPos()).normalize().multiply(kbStrength);
+                    if (pushDir.lengthSquared() > 0) {
+                        pushDir = pushDir.normalize().multiply(kbStrength);
+                    } else {
+                        pushDir = new Vec3d(0, kbStrength, 0); // Đẩy thẳng lên trời nếu trùng vị trí
+                    }
+                    target.addVelocity(pushDir.x, pushDir.y + 0.2, pushDir.z);
+                    target.velocityModified = true;
+                }
+            }
         }
         this.discard();
     }

--- a/src/main/java/net/soulsweaponry/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/soulsweaponry/mixin/LivingEntityMixin.java
@@ -50,13 +50,64 @@ public class LivingEntityMixin {
     /*
      * NB! Only called if the damage is bigger than 0 (decimals count)
      */
+//    @ModifyReturnValue(method = "modifyAppliedDamage", at = @At("TAIL"))
+//    private float modifyDamageReturnValue(float originalAmount) {
+//        LivingEntity entity = (LivingEntity) (Object) this;
+//        if (capturedDamageSource != null) {
+//            return ModifyDamageUtil.modifyDamageTakenTail(entity, originalAmount, capturedDamageSource);
+//        }
+//        return originalAmount;
+//    }
+
+    // Dmg Cap (25%) + Gating (in 10 tick = 0.5s) FOR BOSS (Boss Entity and any Mob with >= 200 HP)
     @ModifyReturnValue(method = "modifyAppliedDamage", at = @At("TAIL"))
     private float modifyDamageReturnValue(float originalAmount) {
         LivingEntity entity = (LivingEntity) (Object) this;
+        float finalAmount = originalAmount;
+
         if (capturedDamageSource != null) {
-            return ModifyDamageUtil.modifyDamageTakenTail(entity, originalAmount, capturedDamageSource);
+            finalAmount = ModifyDamageUtil.modifyDamageTakenTail(entity, finalAmount, capturedDamageSource);
         }
-        return originalAmount;
+
+        if (entity instanceof net.soulsweaponry.entity.mobs.BossEntity || entity.getMaxHealth() >= 200.0f) {
+
+            float maxDamageLimit = entity.getMaxHealth() * 0.25f;
+
+            //CASE 1: POSTURE BREAK
+            if (entity.hasStatusEffect(EffectRegistry.POSTURE_BREAK)) {
+                this.souls_wasPostureBroken = true;
+
+                if (this.souls_damageTakenDuringPostureBreak + finalAmount > maxDamageLimit) {
+                    finalAmount = maxDamageLimit - this.souls_damageTakenDuringPostureBreak;
+                    if (finalAmount <= 0f) return 0f;
+                }
+                this.souls_damageTakenDuringPostureBreak += finalAmount;
+            }
+            //CASE 2: NORMAL
+            else {
+                if (this.souls_wasPostureBroken) {
+                    this.souls_damageTakenDuringPostureBreak = 0f;
+                    this.souls_wasPostureBroken = false;
+                    this.souls_damageTakenThisWindow = 0f;
+                    this.souls_lastDamageWindowTick = entity.age;
+                }
+
+                int currentTick = entity.age;
+                //10 tick
+                if (currentTick - this.souls_lastDamageWindowTick > 10) {
+                    this.souls_damageTakenThisWindow = 0f;
+                    this.souls_lastDamageWindowTick = currentTick;
+                }
+
+                if (this.souls_damageTakenThisWindow + finalAmount > maxDamageLimit) {
+                    finalAmount = maxDamageLimit - this.souls_damageTakenThisWindow;
+                    if (finalAmount <= 0f) return 0f;
+                }
+                this.souls_damageTakenThisWindow += finalAmount;
+            }
+        }
+
+        return finalAmount;
     }
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
@@ -248,4 +299,14 @@ public class LivingEntityMixin {
             abilities.getAbilities().forEach(a -> a.onEquipStack(entity, slot, oldStack, newStack));
         }
     }
+
+    //Damage Cap + Gating
+    @Unique
+    private int souls_lastDamageWindowTick = 0;
+    @Unique
+    private float souls_damageTakenThisWindow = 0f;
+    @Unique
+    private float souls_damageTakenDuringPostureBreak = 0f;
+    @Unique
+    private boolean souls_wasPostureBroken = false;
 }


### PR DESCRIPTION
### Description
Currently, the automatic block-breaking logic for `ReturningKnight` and `Moonknight` only checks if a block is a `BlockWithEntity` before breaking it. This allows them to unintentionally destroy indestructible blocks like **Bedrock** (hardness `-1.0`) as well as utility blocks (Command Blocks, Barriers, End Portal Frames).

This PR resolves the issue by adding two conditions within the `breakBlock` loop inside their `mobTick()` methods:
1. `targetState.getHardness(this.getWorld(), targetPos) >= 0.0F`: Prevents destroying Bedrock and other blocks with negative hardness values.
2. `!targetState.isIn(net.minecraft.registry.tag.BlockTags.WITHER_IMMUNE)`: Properly respects the vanilla `#minecraft:wither_immune` tag to protect structural and map-making blocks.

*Note: Bosses are still capable of breaking Obsidian since its hardness is 50.0F and it is not included in the default wither-immune tag, keeping the arena constraints challenging without breaking world boundaries.*

### Files Changed
- `src/main/java/net/soulsweaponry/entity/mobs/ReturningKnight.java`
- `src/main/java/net/soulsweaponry/entity/mobs/Moonknight.java`