### PR TITLE
fix: prevent bosses from breaking bedrock and wither-immune blocks

### DIFF
--- a/src/main/java/net/soulsweaponry/entity/mobs/Moonknight.java
+++ b/src/main/java/net/soulsweaponry/entity/mobs/Moonknight.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.ProjectileEntity;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
@@ -299,8 +300,13 @@ public class Moonknight extends BossEntity implements GeoEntity {
                     for (int l = -3; l <= 3; ++l) {
                         for (int m = -3; m <= 3; ++m) {
                             for (int n = 0; n <= 8; ++n) {
-                                if (!(this.getWorld().getBlockState(new BlockPos(j + l, i + n, k + m)).getBlock() instanceof BlockWithEntity)) {
-                                    this.getWorld().breakBlock(new BlockPos(j + l, i + n, k + m), true);
+                                //Condition: not WITHER_IMMUNE Block
+                                BlockPos targetPos = new BlockPos(j + l, i + n, k + m);
+                                net.minecraft.block.BlockState targetState = this.getWorld().getBlockState(targetPos);
+                                if (!(targetState.getBlock() instanceof BlockWithEntity)
+                                        && targetState.getHardness(this.getWorld(), targetPos) >= 0.0F
+                                        && !targetState.isIn(BlockTags.WITHER_IMMUNE)) {
+                                    this.getWorld().breakBlock(targetPos, true);
                                 }
                             }
                         }

--- a/src/main/java/net/soulsweaponry/entity/mobs/ReturningKnight.java
+++ b/src/main/java/net/soulsweaponry/entity/mobs/ReturningKnight.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.entity.projectile.ProjectileEntity;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
@@ -341,8 +342,13 @@ public class ReturningKnight extends BossEntity implements GeoEntity {
                     for (int l = -3; l <= 3; ++l) {
                         for (int m = -3; m <= 3; ++m) {
                             for (int n = 0; n <= 8; ++n) {
-                                if (!(this.getWorld().getBlockState(new BlockPos(j + l, i + n, k + m)).getBlock() instanceof BlockWithEntity)) {
-                                    this.getWorld().breakBlock(new BlockPos(j + l, i + n, k + m), true);
+                                //Condition: not WITHER_IMMUNE Block
+                                BlockPos targetPos = new BlockPos(j + l, i + n, k + m);
+                                net.minecraft.block.BlockState targetState = this.getWorld().getBlockState(targetPos);
+                                if (!(targetState.getBlock() instanceof BlockWithEntity)
+                                        && targetState.getHardness(this.getWorld(), targetPos) >= 0.0F
+                                        && !targetState.isIn(BlockTags.WITHER_IMMUNE)) {
+                                    this.getWorld().breakBlock(targetPos, true);
                                 }
                             }
                         }


### PR DESCRIPTION
### Description
This PR addresses an issue where certain bosses (`Moonknight` and `ReturningKnight`) could destroy unbreakable blocks (like Bedrock) and utility blocks protected by the game's default rules.

### Changes
- Added a block hardness check (`targetState.getHardness(...) >= 0.0F`) to prevent the destruction of indestructible blocks.
- Added a tag check for `BlockTags.WITHER_IMMUNE` to ensure blocks like command blocks or end portals are safe from boss attacks.
- Synchronized and merged the latest updates from the upstream `1.21.1` branch.

### Notes
This is a clean rewrite of the previous PR to replace the outdated branch. Thank you for your patience and for the helpful feedback on coding style!